### PR TITLE
fix error 'cannot find module'

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "test": "mocha"
   },
   "dependencies": {
-    "event-stream": "*"
-  },
-  "devDependencies": {
-    "mocha": "~1.14.0",
-    "should": "~2.1.0",
+    "event-stream": "*",
     "gulp-util": "~2.2.0",
     "htmlhint": "~0.9.3",
     "lodash": "~2.4.1"
+  },
+  "devDependencies": {
+    "mocha": "~1.14.0",
+    "should": "~2.1.0"
   },
   "engines": {
     "node": ">=0.8.0",


### PR DESCRIPTION
Installing with `npm i --save-dev` causes "cannot find module".
