### PR TITLE
Update package.json - htmlhint dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "event-stream": "*",
     "gulp-util": "~2.2.0",
-    "htmlhint": "~0.9.3",
+    "htmlhint": "~0.9.5",
     "lodash": "~2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The htmlhint dependency is throwing an error that version 0.9.3 cant be found. The different between 0.9.3 and 0.9.5 is minor.
