### PR TITLE
feat(reporter): custom reporter can be loaded by its package name

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,9 +145,13 @@ htmlhintPlugin.reporter = function(customReporter){
         reporter = customReporter;
     }
 
-    if (customReporter === 'fail') {
-        return htmlhintPlugin.failReporter();
-    }
+	if (typeof customReporter === 'string') {
+	    if (customReporter === 'fail') {
+	        return htmlhintPlugin.failReporter();
+	    } else {
+	    	reporter = require(customReporter);
+	    }
+	}
 
     if (typeof reporter === 'undefined') {
         throw new Error('Invalid reporter');

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "through2": "^2.0.0"
   },
   "devDependencies": {
+    "htmlhint-stylish": "^1.0.0",
     "jshint": "^2.6.3",
     "mocha": "^2.2.1",
     "should": "^7.0.1",

--- a/test/main.js
+++ b/test/main.js
@@ -203,6 +203,32 @@ describe('htmlhint.reporter', function() {
         });
     });
 
+	it('should load custom reporters by package name', function(done) {
+		var valid = 0;
+
+        var stream = vfs.src('test/fixtures/valid.html')
+	        .pipe(htmlhint())
+	        .pipe(htmlhint.reporter('htmlhint-stylish'));
+
+		stream.on('error', function(err) {
+			should.not.exist(err);
+		});
+
+		stream.on('data', function(file) {
+			should.exist(file);
+			file.htmlhint.success.should.be.true;
+            should.exist(file.path);
+            should.exist(file.relative);
+            should.exist(file.contents);
+            ++valid;
+		});
+
+	    stream.once('end', function() {
+			valid.should.equal(1);
+	        done();
+	    });
+	});
+
 });
 
 describe('htmlhint.errorreporter', function(){


### PR DESCRIPTION
```js
var htmlhint = require('gulp-htmlhint');

gulp.src('./src/*.html')
    .pipe(htmlhint())
    .pipe(htmlhint.reporter('htmlhint-stylish'))
```