### PR TITLE
Add link for `gulp-reporter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ __Plugin options:__
 	  .pipe(htmlhint.failReporter({ suppress: true }))
   ```
 
+### Third party reporter
+
+[gulp-reporter](https://github.com/gucong3000/gulp-reporter) is used in a team project and fails only when the error belongs to the current author.
+
 ## License
 
 [MIT License](bezoerb.mit-license.org)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ __Plugin options:__
 
 ### Third party reporter
 
-[gulp-reporter](https://github.com/gucong3000/gulp-reporter) is used in a team project and fails only when the error belongs to the current author.
+[gulp-reporter](https://github.com/gucong3000/gulp-reporter) used in team project, it fails only when error belongs to the current author of git.
 
 ## License
 


### PR DESCRIPTION
[gulp-reporter](https://github.com/gucong3000/gulp-reporter) used in team project, it fails only when error belongs to the current author of git.
